### PR TITLE
Moving express types to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
     "dev": "ts-node-dev --transpile-only --ignore-watch node_modules src/server.ts"
   },
   "dependencies": {
-    "@types/express": "^4.17.11",
     "express": "^4.17.1"
   },
   "devDependencies": {
+    "@types/express": "^4.17.11",
     "ts-node-dev": "^1.1.2",
     "typescript": "^4.2.2"
   }


### PR DESCRIPTION
Os types não são utilizados em produção, então não precisa deixar eles nas dependências normais